### PR TITLE
Directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 This provider plugin is maintained by:
 
 * Benjamin P. Jung <headcr4sh@gmail.com>
+* Nick Larsen <nick@aptiv.co.nz>
 
 ## Requirements
 

--- a/concourse/config.go
+++ b/concourse/config.go
@@ -1,4 +1,4 @@
-package main
+package concourse
 
 import (
 	"encoding/json"

--- a/concourse/data_caller_identity.go
+++ b/concourse/data_caller_identity.go
@@ -1,4 +1,4 @@
-package main
+package concourse
 
 import (
 	"fmt"

--- a/concourse/data_server_info.go
+++ b/concourse/data_server_info.go
@@ -1,4 +1,4 @@
-package main
+package concourse
 
 import (
 	"fmt"

--- a/concourse/data_team.go
+++ b/concourse/data_team.go
@@ -1,4 +1,4 @@
-package main
+package concourse
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"

--- a/concourse/provider.go
+++ b/concourse/provider.go
@@ -1,4 +1,4 @@
-package main
+package concourse
 
 import (
 	"fmt"

--- a/concourse/resource_pipeline.go
+++ b/concourse/resource_pipeline.go
@@ -1,4 +1,4 @@
-package main
+package concourse
 
 import (
 		"fmt"

--- a/concourse/resource_team.go
+++ b/concourse/resource_team.go
@@ -1,4 +1,4 @@
-package main
+package concourse
 
 import (
 		"fmt"

--- a/main.go
+++ b/main.go
@@ -3,12 +3,13 @@ package main
 import (
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
+	"terraform-provider-concourse/concourse"
 )
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: func() terraform.ResourceProvider {
-			return Provider()
+			return concourse.Provider()
 		},
 	})
 }


### PR DESCRIPTION
I thought it might be a good idea to move the provider code into a subdirectory to keep the root clean.
The root still contains `main.go`