### PR TITLE
Flyrc logic split

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 This provider plugin is maintained by:
 
 * Benjamin P. Jung <headcr4sh@gmail.com>
+* Nick Larsen <nick@aptiv.co.nz>
 
 ## Requirements
 

--- a/concourse/config.go
+++ b/concourse/config.go
@@ -1,4 +1,4 @@
-package main
+package concourse
 
 import (
 	"encoding/json"

--- a/concourse/data_caller_identity.go
+++ b/concourse/data_caller_identity.go
@@ -1,4 +1,4 @@
-package main
+package concourse
 
 import (
 	"fmt"

--- a/concourse/data_server_info.go
+++ b/concourse/data_server_info.go
@@ -1,4 +1,4 @@
-package main
+package concourse
 
 import (
 	"fmt"

--- a/concourse/data_team.go
+++ b/concourse/data_team.go
@@ -1,4 +1,4 @@
-package main
+package concourse
 
 import (
 	"github.com/hashicorp/terraform/helper/schema"

--- a/concourse/fly_config.go
+++ b/concourse/fly_config.go
@@ -1,0 +1,71 @@
+package concourse
+
+import (
+	"fmt"
+	"gopkg.in/yaml.v1"
+	"io/ioutil"
+	"os"
+	"os/user"
+)
+
+// FlyRC is a representation of the configuration file structure that is stored by the
+// "fly" command line interface. (Usually to be found in ~/.flyrc)
+type FlyRC struct {
+	Targets map[string]Target `yaml:"targets"`
+}
+
+type Target struct {
+	API      string `yaml:"api"`
+	Team     string `yaml:"team"`
+	Insecure bool   `yaml:"insecure,omitempty"`
+	Token    struct {
+		Type  string `yaml:"type"`
+		Value string `yaml:"value"`
+	} `yaml:"token"`
+}
+
+// Reads in a `flyrc` file and returns a FlyRC struct
+func (rc *FlyRC) ImportConfig() error {
+	cfg := FlyRC{}
+
+	flyrc_path, err := flyRcLocation()
+	if err != nil {
+		return err
+	}
+
+	flyrc_contents, err := flyReadConfig(flyrc_path)
+	if err != nil {
+		return err
+	}
+
+	yaml.Unmarshal(*flyrc_contents, cfg)
+
+	return nil
+}
+
+func flyRcLocation() (*string, error) {
+	// Check if an ENV var has been set with a path
+	// Todo: Find out if this is the correct ENV var, or if it fly even has one.
+	if flyrc, ok := os.LookupEnv("FLYRC"); ok {
+		return &flyrc, nil
+	}
+
+	// Otherwise, return the default flyrc location
+	cu, err := user.Current()
+	if err != nil {
+		return nil, fmt.Errorf("unable to determine current user for reading the .flyrc file: %v", err)
+	}
+	flyrc := fmt.Sprintf("%s/.flyrc", cu.HomeDir)
+	return &flyrc, nil
+}
+
+// Get the bytes of the flyrc config based on the filepath given
+func flyReadConfig(flyrc *string) (*[]byte, error) {
+	if _, err := os.Stat(*flyrc); err != nil {
+		return nil, fmt.Errorf("unable to stat the flyrc file (%s): %v", *flyrc, err)
+	}
+
+	config_bytes, err := ioutil.ReadFile(*flyrc)
+
+	return &config_bytes, err
+}

--- a/concourse/provider.go
+++ b/concourse/provider.go
@@ -1,4 +1,4 @@
-package main
+package concourse
 
 import (
 	"fmt"

--- a/concourse/provider.go
+++ b/concourse/provider.go
@@ -3,28 +3,11 @@ package concourse
 import (
 	"fmt"
 	"github.com/hashicorp/terraform/helper/schema"
-	"gopkg.in/yaml.v2"
-	"net/http"
-		"net/url"
-	"os"
-	"os/user"
-	"strings"
 	"golang.org/x/oauth2"
+	"net/http"
+	"net/url"
+	"strings"
 )
-
-// FlyRC is a representation of the configuration file structure that is stored by the
-// "fly" command line interface. (Usually to be found in ~/.flyrc)
-type FlyRC struct {
-	Targets map[string]struct {
-		API      string `yaml:"api"`
-		Team     string `yaml:"team"`
-		Insecure bool   `yaml:"insecure,omitempty"`
-		Token    struct {
-			Type  string `yaml:"type"`
-			Value string `yaml:"value"`
-		} `yaml:"token"`
-	} `yaml:"targets"`
-}
 
 // SkyUserInfo encapsulates all the information that is being reported by the Sky marshal
 // "sky/userinfo" REST endpoint
@@ -61,13 +44,13 @@ func Provider() *schema.Provider {
 				Description:   "Authentication token type",
 				Type:          schema.TypeString,
 				Optional:      true,
-				Default: "Bearer",
+				Default:       "Bearer",
 				ConflictsWith: []string{"target"},
 			},
 			"auth_token_value": {
-				Description: "Authentication token value",
-				Type: schema.TypeString,
-				Optional: true,
+				Description:   "Authentication token value",
+				Type:          schema.TypeString,
+				Optional:      true,
 				ConflictsWith: []string{"target"},
 			},
 			"target": {
@@ -78,7 +61,7 @@ func Provider() *schema.Provider {
 			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
-			"concourse_team": resourceTeam(),
+			"concourse_team":     resourceTeam(),
 			"concourse_pipeline": resourcePipeline(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
@@ -102,22 +85,12 @@ func configure(d *schema.ResourceData) (interface{}, error) {
 	// Let's try to read the fly CLI configuration file if the user did not specify
 	// any connection parameters in the provider configuration.
 	if targetName != "" {
-		cu, err := user.Current()
-		if err != nil {
-			return nil, fmt.Errorf("unable to determine current user: %v", err)
-		}
-		cfgFilePath := fmt.Sprintf("%s/.flyrc", cu.HomeDir)
-		if _, err := os.Stat(cfgFilePath); err != nil {
-			return nil, fmt.Errorf("unable to find Fly configuration file (%s): %v", cfgFilePath, err)
-		}
-		cfgFile, err := os.Open(cfgFilePath)
-		if err != nil {
-			return nil, fmt.Errorf("unable to open Fly configuration file (%s): %v", cfgFile.Name(), err)
-		}
 		cfg := FlyRC{}
-		if yaml.NewDecoder(cfgFile).Decode(&cfg); err != nil {
-			return nil, fmt.Errorf("unable to parse Fly configuration file (%s): %v", cfgFile.Name(), err)
+		err := cfg.ImportConfig()
+		if err != nil {
+			return nil, fmt.Errorf("fly configuration parse error: %v", err)
 		}
+
 		if len(cfg.Targets) <= 0 {
 			return nil, fmt.Errorf("no targets found in Fly configuration file (%s)", cfgFile.Name())
 		}
@@ -162,7 +135,7 @@ func configure(d *schema.ResourceData) (interface{}, error) {
 
 	}
 	oAuthToken := &oauth2.Token{
-		TokenType: authTokenType,
+		TokenType:   authTokenType,
 		AccessToken: authTokenValue,
 	}
 	transport := &oauth2.Transport{

--- a/concourse/provider.go
+++ b/concourse/provider.go
@@ -88,18 +88,18 @@ func configure(d *schema.ResourceData) (interface{}, error) {
 		cfg := FlyRC{}
 		err := cfg.ImportConfig()
 		if err != nil {
-			return nil, fmt.Errorf("fly configuration parse error: %v", err)
+			return nil, fmt.Errorf("unable to parse Fly configuration file (%s): %v", cfg.Filename, err)
 		}
 
 		if len(cfg.Targets) <= 0 {
-			return nil, fmt.Errorf("no targets found in Fly configuration file (%s)", cfgFile.Name())
+			return nil, fmt.Errorf("no targets found in Fly configuration file (%s)", cfg.Filename)
 		}
 		if targetName == "" {
 			return nil, fmt.Errorf("provider argument \"target\" must be specified")
 		}
 		target, exists := cfg.Targets[targetName]
 		if !exists {
-			return nil, fmt.Errorf("unable to find targetName with ID \"%s\" in Fly configuration file %s", targetName, cfgFile.Name())
+			return nil, fmt.Errorf("unable to find targetName with ID \"%s\" in Fly configuration file %s", targetName, cfg.Filename)
 		}
 		concourseURL = target.API
 		if u, err = url.Parse(concourseURL); err != nil {

--- a/concourse/resource_pipeline.go
+++ b/concourse/resource_pipeline.go
@@ -1,4 +1,4 @@
-package main
+package concourse
 
 import (
 		"fmt"

--- a/concourse/resource_team.go
+++ b/concourse/resource_team.go
@@ -1,4 +1,4 @@
-package main
+package concourse
 
 import (
 		"fmt"

--- a/main.go
+++ b/main.go
@@ -3,12 +3,13 @@ package main
 import (
 	"github.com/hashicorp/terraform/plugin"
 	"github.com/hashicorp/terraform/terraform"
+	"terraform-provider-concourse/concourse"
 )
 
 func main() {
 	plugin.Serve(&plugin.ServeOpts{
 		ProviderFunc: func() terraform.ResourceProvider {
-			return Provider()
+			return concourse.Provider()
 		},
 	})
 }


### PR DESCRIPTION
I've moved the logic for reading the `.flyrc` to another file, and added methods to the FlyRC type.
The diff will look better against the directory structure reorganisation commit in #1 